### PR TITLE
fix StreamIO read

### DIFF
--- a/src/IO/StreamIO.php
+++ b/src/IO/StreamIO.php
@@ -147,7 +147,7 @@ class StreamIO extends AbstractIO implements Reader
         $bytes = fread($this->socket, $size);
 
         // socket is closed
-        if ($bytes == '' && feof($this->socket)) {
+        if (\feof($this->socket) || !\is_resource($this->socket) || $bytes === false) {
             $this->close();
             throw new IOException('socket is closed');
         }


### PR DESCRIPTION
修复 在返回 false 时无法检测出 连接断开的情况，还可能导致 handleRead 出现死循环的问题