### PR TITLE
Allow zero receive_queue_size

### DIFF
--- a/src/ConsumerOptions.php
+++ b/src/ConsumerOptions.php
@@ -144,7 +144,7 @@ final class ConsumerOptions extends Options
      */
     public function setReceiveQueueSize(int $size)
     {
-        if ($size <= 0) {
+        if ($size < 0) {
             $size = 1000;
         }
         $this->data[ self::RECEIVE_QUEUE_SIZE ] = $size;


### PR DESCRIPTION
Allow to set zero value of $size in setReceiveQueueSize(int $size)

see [#26](https://github.com/ikilobyte/pulsar-client-php/issues/26)
