### PR TITLE
fix: preserve message properties when sending messages to the DLQ topic

### DIFF
--- a/src/Policy/DeadLetterPolicy.php
+++ b/src/Policy/DeadLetterPolicy.php
@@ -17,6 +17,7 @@ use Pulsar\ConsumerOptions;
 use Pulsar\Exception;
 use Pulsar\Exception\OptionsException;
 use Pulsar\Message;
+use Pulsar\MessageOptions;
 use Pulsar\Options;
 use Pulsar\Producer;
 use Pulsar\ProducerOptions;
@@ -139,7 +140,9 @@ class DeadLetterPolicy
 
         $producer = new Producer($this->options->getUrl()['url'], $options);
         $producer->connect();
-        $producer->send($message->getPayload());
+        $producer->send($message->getPayload(), [
+            MessageOptions::PROPERTIES => $message->getProperties(),
+        ]);
         $producer->close();
     }
 }


### PR DESCRIPTION
## Summary

Fix Dead Letter Policy to preserve original message properties when sending messages to the DLQ topic.

## Problem

When a message reaches the retry limit and is sent to the DLQ topic through the Dead Letter Policy, the original message properties are not preserved.

This causes issues for consumers that depend on message properties, such as:

- `Content-Type`
- Symfony Messenger stamps (`X-Message-Stamp-*`)
- custom metadata
- message type information

The current implementation sends only the payload to the DLQ topic:

```php
$producer->send($message->getPayload());
```

As a result, the message received in the DLQ loses all original properties.

## Solution

Send the original message properties together with the payload when publishing to the DLQ topic.

### Before

```php
$producer->send($message->getPayload());
```

### After

```php
$producer->send($message->getPayload(), [
    MessageOptions::PROPERTIES => $message->getProperties(),
]);
```

## Result

Messages sent to the DLQ topic now preserve their original properties, allowing consumers and frameworks such as Symfony Messenger to correctly deserialize and process the message.

## Evidence

### Normal topic message

The original message contains the expected properties:

- `Content-Type: application/json`
- `X-Message-Stamp-Symfony\Component\Messenger\Stamp\BusNameStamp`
- `type`

<img width="1046" height="304" alt="Image" src="https://github.com/user-attachments/assets/367a9068-6354-4e82-901f-9402c006373b" />

### DLQ message before fix

The DLQ message only contains internal Pulsar properties:

- `X-Pulsar-batch-size`
- `X-Pulsar-num-batch-message`

<img width="1046" height="304" alt="Image" src="https://github.com/user-attachments/assets/89b671da-4456-4bbc-a77e-53f93ebccbfa" />

The application properties are missing.

### DLQ message after fix

The DLQ message now preserves the original application properties correctly.

<img width="1046" height="304" alt="Screenshot from 2026-05-09 19-02-29" src="https://github.com/user-attachments/assets/b57fad8e-9373-4490-9f10-03155f0dc9f2" />

## Related issue

Fixes #42