### PR TITLE
feat: add MCP stdio server for AI agent integration

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -11,6 +11,7 @@
     * [Schema](#Schema)
     * [Reader](#Reader)
     * [可选项配置](#可选项配置)
+    * [MCP Server（AI Agent 集成）](#MCP-ServerAI-Agent-集成)
     * [License](#License)
 
 ## 关于
@@ -485,6 +486,31 @@ $reader->close();
 
 * `MessageNotFound::Ignore`
 * `MessageNotFound::CommandParseFail`
+
+## MCP Server（AI Agent 集成）
+
+本项目内置 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) stdio 服务器，让 AI Agent（Cursor、Claude Desktop 等）直接操作 Pulsar 消息队列。无需额外依赖。
+
+**工具：** `pulsar_publish`（发送）· `pulsar_consume`（消费）· `pulsar_peek`（只读浏览）
+
+**快速接入** — 添加到 `~/.cursor/mcp.json`（Cursor）或 `claude_desktop_config.json`（Claude Desktop）：
+
+```json
+{
+  "mcpServers": {
+    "pulsar": {
+      "command": "php",
+      "args": ["/path/to/pulsar-client-php/examples/mcp-server.php"],
+      "env": {
+        "PULSAR_BROKER_URL": "pulsar://localhost:6650",
+        "PULSAR_TOKEN": ""
+      }
+    }
+  }
+}
+```
+
+完整工具参考和测试说明请查看 [examples/mcp.md](examples/mcp.md)。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     * [Schema](#Schema)
     * [Reader](#Reader)
     * [Options](#Options)
+    * [MCP Server for AI Agents](#MCP-Server-for-AI-Agents)
     * [License](#License)
 
 ## About
@@ -499,6 +500,31 @@ $reader->close();
 
 * `MessageNotFound::Ignore`
 * `MessageNotFound::CommandParseFail`
+
+## MCP Server for AI Agents
+
+This library includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) stdio server that lets AI agents (Cursor, Claude Desktop, etc.) produce, consume, and peek at Pulsar messages. No extra dependencies required.
+
+**Tools:** `pulsar_publish` · `pulsar_consume` · `pulsar_peek`
+
+**Quick setup** — add to `~/.cursor/mcp.json` (Cursor) or `claude_desktop_config.json` (Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "pulsar": {
+      "command": "php",
+      "args": ["/path/to/pulsar-client-php/examples/mcp-server.php"],
+      "env": {
+        "PULSAR_BROKER_URL": "pulsar://localhost:6650",
+        "PULSAR_TOKEN": ""
+      }
+    }
+  }
+}
+```
+
+See [examples/mcp.md](examples/mcp.md) for full tool reference and testing instructions.
 
 ## License
 

--- a/examples/mcp-server.php
+++ b/examples/mcp-server.php
@@ -1,0 +1,489 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Pulsar\Authentication\Jwt;
+use Pulsar\Consumer;
+use Pulsar\ConsumerOptions;
+use Pulsar\Exception\MessageNotFound;
+use Pulsar\Message;
+use Pulsar\MessageOptions;
+use Pulsar\Options;
+use Pulsar\Producer;
+use Pulsar\ProducerOptions;
+use Pulsar\Reader;
+use Pulsar\ReaderOptions;
+use Pulsar\SubscriptionType;
+
+/**
+ * Minimal MCP (Model Context Protocol) server exposing Apache Pulsar
+ * produce / consume / peek operations as tools for AI agents.
+ *
+ * Transport : stdio (line-delimited JSON-RPC 2.0)
+ * Env vars  : PULSAR_BROKER_URL (default pulsar://localhost:6650)
+ *             PULSAR_TOKEN      (optional JWT token)
+ */
+class PulsarMcpServer
+{
+    const PROTOCOL_VERSION = '2024-11-05';
+    const SERVER_NAME      = 'pulsar-mcp-server';
+    const SERVER_VERSION   = '0.1.0';
+
+    /** @var string */
+    private $brokerUrl;
+
+    /** @var string|null */
+    private $token;
+
+    public function __construct()
+    {
+        $this->brokerUrl = getenv('PULSAR_BROKER_URL') ?: 'pulsar://localhost:6650';
+        $token = getenv('PULSAR_TOKEN');
+        $this->token = ($token !== false && $token !== '') ? $token : null;
+    }
+
+    public function run()
+    {
+        $this->log('Server started, broker=%s', $this->brokerUrl);
+
+        while (($line = fgets(STDIN)) !== false) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+
+            $request = json_decode($line, true);
+            if (!is_array($request)) {
+                continue;
+            }
+
+            $response = $this->dispatch($request);
+            if ($response !== null) {
+                fwrite(STDOUT, json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
+                fflush(STDOUT);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  JSON-RPC dispatch
+    // ------------------------------------------------------------------ //
+
+    private function dispatch(array $request)
+    {
+        $method = isset($request['method']) ? $request['method'] : '';
+        $id     = isset($request['id']) ? $request['id'] : null;
+        $params = isset($request['params']) ? $request['params'] : [];
+
+        $this->log('Received method=%s id=%s', $method, json_encode($id));
+
+        switch ($method) {
+            case 'initialize':
+                return $this->handleInitialize($id);
+
+            case 'notifications/initialized':
+                return null;
+
+            case 'ping':
+                return $this->result($id, []);
+
+            case 'tools/list':
+                return $this->handleToolsList($id);
+
+            case 'tools/call':
+                return $this->handleToolsCall($id, $params);
+
+            default:
+                if ($id !== null) {
+                    return $this->error($id, -32601, 'Method not found: ' . $method);
+                }
+                return null;
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  MCP handlers
+    // ------------------------------------------------------------------ //
+
+    private function handleInitialize($id)
+    {
+        return $this->result($id, [
+            'protocolVersion' => self::PROTOCOL_VERSION,
+            'capabilities'    => [
+                'tools' => new \stdClass(),
+            ],
+            'serverInfo' => [
+                'name'    => self::SERVER_NAME,
+                'version' => self::SERVER_VERSION,
+            ],
+        ]);
+    }
+
+    private function handleToolsList($id)
+    {
+        return $this->result($id, [
+            'tools' => $this->toolDefinitions(),
+        ]);
+    }
+
+    private function handleToolsCall($id, array $params)
+    {
+        $name = isset($params['name']) ? $params['name'] : '';
+        $args = isset($params['arguments']) ? $params['arguments'] : [];
+
+        try {
+            switch ($name) {
+                case 'pulsar_publish':
+                    $payload = $this->doPublish($args);
+                    break;
+                case 'pulsar_consume':
+                    $payload = $this->doConsume($args);
+                    break;
+                case 'pulsar_peek':
+                    $payload = $this->doPeek($args);
+                    break;
+                default:
+                    return $this->toolError($id, 'Unknown tool: ' . $name);
+            }
+
+            return $this->result($id, [
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT),
+                    ],
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            $this->log('Tool %s error: %s', $name, $e->getMessage());
+            return $this->toolError($id, $e->getMessage());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Tool: pulsar_publish
+    // ------------------------------------------------------------------ //
+
+    private function doPublish(array $args)
+    {
+        $topic   = $this->requireString($args, 'topic');
+        $payload = $this->requireString($args, 'payload');
+
+        $options = new ProducerOptions();
+        $options->setConnectTimeout(3);
+        $options->setTopic($topic);
+        $this->applyAuth($options);
+
+        $producer = new Producer($this->brokerUrl, $options);
+        $producer->connect();
+
+        $msgOpts = [];
+        if (isset($args['key']) && $args['key'] !== '') {
+            $msgOpts[MessageOptions::KEY] = (string)$args['key'];
+        }
+        if (isset($args['properties']) && is_array($args['properties'])) {
+            $msgOpts['properties'] = $args['properties'];
+        }
+        if (isset($args['delay_seconds']) && (int)$args['delay_seconds'] > 0) {
+            $msgOpts[MessageOptions::DELAY_SECONDS] = (int)$args['delay_seconds'];
+        }
+
+        $messageId = $producer->send($payload, $msgOpts);
+        $producer->close();
+
+        return ['message_id' => $messageId];
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Tool: pulsar_consume
+    // ------------------------------------------------------------------ //
+
+    private function doConsume(array $args)
+    {
+        $topic        = $this->requireString($args, 'topic');
+        $subscription = $this->requireString($args, 'subscription');
+        $subTypeName  = isset($args['subscription_type']) ? (string)$args['subscription_type'] : 'Shared';
+        $maxMessages  = isset($args['max_messages']) ? max(1, (int)$args['max_messages']) : 10;
+        $timeout      = isset($args['timeout_seconds']) ? max(1, (int)$args['timeout_seconds']) : 3;
+
+        $options = new ConsumerOptions();
+        $options->setConnectTimeout(3);
+        $options->setTopic($topic);
+        $options->setSubscription($subscription);
+        $options->setSubscriptionType($this->resolveSubType($subTypeName));
+        $options->setNackRedeliveryDelay($timeout);
+        $options->setReconnectPolicy(false);
+        $this->applyAuth($options);
+
+        $consumer = new Consumer($this->brokerUrl, $options);
+        $consumer->connect();
+
+        $messages = [];
+        $deadline = time() + $timeout;
+
+        for ($i = 0; $i < $maxMessages; $i++) {
+            if (time() >= $deadline) {
+                break;
+            }
+            try {
+                $message = $consumer->receive(false);
+                $messages[] = $this->formatMessage($message);
+                $consumer->ack($message);
+            } catch (MessageNotFound $e) {
+                if ($e->getCode() === MessageNotFound::Ignore) {
+                    break;
+                }
+                throw $e;
+            }
+        }
+
+        $consumer->close();
+
+        return ['messages' => $messages, 'count' => count($messages)];
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Tool: pulsar_peek
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Note: Reader::next() blocks internally (up to 30 s per attempt) until a
+     * message arrives.  The wall-clock timeout is enforced *between* successive
+     * next() calls but cannot interrupt a single blocking wait.  When reading
+     * from "earliest" on a topic that already has messages, the first call
+     * normally returns immediately.
+     */
+    private function doPeek(array $args)
+    {
+        $topic       = $this->requireString($args, 'topic');
+        $from        = isset($args['from']) ? (string)$args['from'] : 'earliest';
+        $maxMessages = isset($args['max_messages']) ? max(1, (int)$args['max_messages']) : 10;
+        $timeout     = isset($args['timeout_seconds']) ? max(1, (int)$args['timeout_seconds']) : 2;
+
+        $options = new ReaderOptions();
+        $options->setConnectTimeout(3);
+        $options->setTopic($topic);
+        $this->applyAuth($options);
+
+        if ($from === 'latest') {
+            $options->setStartMessageID(Message::latestMessageIdData());
+        } else {
+            $options->setStartMessageID(Message::earliestMessageIdData());
+        }
+
+        $reader = new Reader($this->brokerUrl, $options);
+        $reader->connect();
+
+        $messages = [];
+        $deadline = time() + $timeout;
+
+        for ($i = 0; $i < $maxMessages; $i++) {
+            if (time() >= $deadline) {
+                break;
+            }
+            try {
+                $message = $reader->next();
+                $messages[] = $this->formatMessage($message);
+            } catch (\Throwable $e) {
+                $this->log('Peek interrupted: %s', $e->getMessage());
+                break;
+            }
+        }
+
+        $reader->close();
+
+        return ['messages' => $messages, 'count' => count($messages)];
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Helpers
+    // ------------------------------------------------------------------ //
+
+    private function formatMessage(Message $message)
+    {
+        return [
+            'message_id'   => $message->getMessageId(),
+            'topic'        => $message->getTopic(),
+            'publish_time' => $message->getPublishTime(),
+            'key'          => $message->getPartitionKey(),
+            'properties'   => $message->getProperties(),
+            'payload'      => $message->getPayload(),
+        ];
+    }
+
+    private function resolveSubType($name)
+    {
+        $map = [
+            'Exclusive'  => SubscriptionType::Exclusive,
+            'Shared'     => SubscriptionType::Shared,
+            'Failover'   => SubscriptionType::Failover,
+            'Key_Shared' => SubscriptionType::Key_Shared,
+            'KeyShared'  => SubscriptionType::Key_Shared,
+        ];
+        return isset($map[$name]) ? $map[$name] : SubscriptionType::Shared;
+    }
+
+    private function applyAuth(Options $options)
+    {
+        if ($this->token !== null) {
+            $options->setAuthentication(new Jwt($this->token));
+        }
+    }
+
+    private function requireString(array $args, $key)
+    {
+        if (!isset($args[$key]) || !is_string($args[$key]) || $args[$key] === '') {
+            throw new \InvalidArgumentException(sprintf('Missing required parameter: %s', $key));
+        }
+        return $args[$key];
+    }
+
+    // ------------------------------------------------------------------ //
+    //  JSON-RPC envelope helpers
+    // ------------------------------------------------------------------ //
+
+    private function result($id, $result)
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id'      => $id,
+            'result'  => $result,
+        ];
+    }
+
+    private function error($id, $code, $message)
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id'      => $id,
+            'error'   => [
+                'code'    => $code,
+                'message' => $message,
+            ],
+        ];
+    }
+
+    private function toolError($id, $message)
+    {
+        return $this->result($id, [
+            'content' => [
+                ['type' => 'text', 'text' => 'Error: ' . $message],
+            ],
+            'isError' => true,
+        ]);
+    }
+
+    private function log($format)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        fwrite(STDERR, sprintf("[%s] %s\n", date('Y-m-d H:i:s'), vsprintf($format, $args)));
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Tool definitions (JSON Schema)
+    // ------------------------------------------------------------------ //
+
+    private function toolDefinitions()
+    {
+        return [
+            [
+                'name'        => 'pulsar_publish',
+                'description' => 'Publish a message to an Apache Pulsar topic. Returns the message ID.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'required'   => ['topic', 'payload'],
+                    'properties' => [
+                        'topic' => [
+                            'type'        => 'string',
+                            'description' => 'Full topic name, e.g. persistent://public/default/my-topic',
+                        ],
+                        'payload' => [
+                            'type'        => 'string',
+                            'description' => 'Message body (string). For structured data use a JSON-encoded string.',
+                        ],
+                        'key' => [
+                            'type'        => 'string',
+                            'description' => 'Optional routing key for partitioned topics.',
+                        ],
+                        'properties' => [
+                            'type'                 => 'object',
+                            'description'          => 'Optional key-value properties attached to the message.',
+                            'additionalProperties' => ['type' => 'string'],
+                        ],
+                        'delay_seconds' => [
+                            'type'        => 'integer',
+                            'description' => 'Delay delivery by N seconds (needs Shared / Key_Shared subscription on consumer).',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'name'        => 'pulsar_consume',
+                'description' => 'Consume (and auto-acknowledge) messages from a Pulsar topic. Returns up to max_messages within the timeout window.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'required'   => ['topic', 'subscription'],
+                    'properties' => [
+                        'topic' => [
+                            'type'        => 'string',
+                            'description' => 'Full topic name, e.g. persistent://public/default/my-topic',
+                        ],
+                        'subscription' => [
+                            'type'        => 'string',
+                            'description' => 'Subscription name.',
+                        ],
+                        'subscription_type' => [
+                            'type'    => 'string',
+                            'enum'    => ['Exclusive', 'Shared', 'Failover', 'Key_Shared'],
+                            'default' => 'Shared',
+                        ],
+                        'max_messages' => [
+                            'type'    => 'integer',
+                            'default' => 10,
+                            'description' => 'Max messages to return (default 10).',
+                        ],
+                        'timeout_seconds' => [
+                            'type'    => 'integer',
+                            'default' => 3,
+                            'description' => 'Max seconds to wait for messages (default 3).',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'name'        => 'pulsar_peek',
+                'description' => 'Peek at messages using a Reader — read-only, no subscription, no acknowledgement. Good for inspecting topic contents.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'required'   => ['topic'],
+                    'properties' => [
+                        'topic' => [
+                            'type'        => 'string',
+                            'description' => 'Full topic name, e.g. persistent://public/default/my-topic',
+                        ],
+                        'from' => [
+                            'type'    => 'string',
+                            'enum'    => ['earliest', 'latest'],
+                            'default' => 'earliest',
+                            'description' => 'Start position: "earliest" for first message, "latest" for new messages only.',
+                        ],
+                        'max_messages' => [
+                            'type'    => 'integer',
+                            'default' => 10,
+                            'description' => 'Max messages to return (default 10).',
+                        ],
+                        'timeout_seconds' => [
+                            'type'    => 'integer',
+                            'default' => 2,
+                            'description' => 'Max seconds to wait for messages (default 2). A single read may block up to 30 s internally if the topic is empty.',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}
+
+(new PulsarMcpServer())->run();

--- a/examples/mcp.md
+++ b/examples/mcp.md
@@ -1,0 +1,228 @@
+# MCP Server for AI Agents
+
+This directory contains a minimal **MCP (Model Context Protocol)** server that
+exposes Apache Pulsar produce / consume / peek operations as tools for AI
+agents such as [Cursor](https://cursor.com) and
+[Claude Desktop](https://claude.ai/download).
+
+The server communicates over **stdio** (line-delimited JSON-RPC 2.0) — no extra
+PHP dependencies are needed beyond the existing `pulsar-client-php` library.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| PHP >= 7.1 | Same as the library itself |
+| Composer dependencies installed | `composer install` in the project root |
+| A running Apache Pulsar broker | Default `pulsar://localhost:6650` |
+
+Quick way to start a local Pulsar broker for testing:
+
+```bash
+docker run -it --rm -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:latest bin/pulsar standalone
+```
+
+---
+
+## Quick Start (manual smoke test)
+
+```bash
+# From the project root
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n' \
+  | php examples/mcp-server.php
+```
+
+You should see two JSON responses on stdout (one for `initialize`, one for
+`tools/list`) and log lines on stderr.
+
+---
+
+## Cursor IDE Configuration
+
+Add the following to your Cursor MCP config (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "pulsar": {
+      "command": "php",
+      "args": ["/absolute/path/to/pulsar-client-php/examples/mcp-server.php"],
+      "env": {
+        "PULSAR_BROKER_URL": "pulsar://localhost:6650",
+        "PULSAR_TOKEN": ""
+      }
+    }
+  }
+}
+```
+
+> Replace `/absolute/path/to` with the real path on your machine.
+> Leave `PULSAR_TOKEN` empty if no JWT authentication is required.
+
+After saving, restart Cursor — the three Pulsar tools will appear in the agent
+tool list.
+
+---
+
+## Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`
+(macOS `~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "pulsar": {
+      "command": "php",
+      "args": ["/absolute/path/to/pulsar-client-php/examples/mcp-server.php"],
+      "env": {
+        "PULSAR_BROKER_URL": "pulsar://localhost:6650",
+        "PULSAR_TOKEN": ""
+      }
+    }
+  }
+}
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PULSAR_BROKER_URL` | `pulsar://localhost:6650` | Pulsar broker URL (`pulsar://`, `pulsar+ssl://`, `http://`, `https://`) |
+| `PULSAR_TOKEN` | *(empty)* | JWT token for authentication. Leave empty to skip auth. |
+
+---
+
+## Tools Reference
+
+### `pulsar_publish`
+
+Publish a message to a Pulsar topic.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `topic` | string | **yes** | — | Full topic, e.g. `persistent://public/default/my-topic` |
+| `payload` | string | **yes** | — | Message body |
+| `key` | string | no | — | Routing key (for partitioned topics) |
+| `properties` | object | no | — | Key-value string properties |
+| `delay_seconds` | integer | no | — | Delay delivery (needs Shared / Key\_Shared subscription) |
+
+**Example call:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+  "params": {
+    "name": "pulsar_publish",
+    "arguments": {
+      "topic": "persistent://public/default/demo",
+      "payload": "{\"hello\":\"world\"}",
+      "properties": {"source": "mcp-agent"}
+    }
+  }
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 10,
+  "result": {
+    "content": [{"type": "text", "text": "{\n    \"message_id\": \"621:103:0\"\n}"}]
+  }
+}
+```
+
+---
+
+### `pulsar_consume`
+
+Consume messages from a topic (auto-acknowledged).
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `topic` | string | **yes** | — | Full topic name |
+| `subscription` | string | **yes** | — | Subscription name |
+| `subscription_type` | string | no | `Shared` | `Exclusive` / `Shared` / `Failover` / `Key_Shared` |
+| `max_messages` | integer | no | `10` | Max messages to return |
+| `timeout_seconds` | integer | no | `3` | Max wait time in seconds |
+
+**Example call:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+  "params": {
+    "name": "pulsar_consume",
+    "arguments": {
+      "topic": "persistent://public/default/demo",
+      "subscription": "mcp-sub",
+      "max_messages": 5
+    }
+  }
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 11,
+  "result": {
+    "content": [{"type": "text", "text": "{\n    \"messages\": [...],\n    \"count\": 3\n}"}]
+  }
+}
+```
+
+Each message object contains: `message_id`, `topic`, `publish_time`, `key`,
+`properties`, `payload`.
+
+---
+
+### `pulsar_peek`
+
+Read messages using a Reader — **read-only**, no subscription side effects, no
+acknowledgement.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `topic` | string | **yes** | — | Full topic name |
+| `from` | string | no | `earliest` | `earliest` or `latest` |
+| `max_messages` | integer | no | `10` | Max messages to return |
+| `timeout_seconds` | integer | no | `2` | Max wait time in seconds |
+
+> **Note:** When reading from `earliest` on a topic with existing messages,
+> results are returned immediately. Reading from `latest` waits for *new*
+> messages and a single internal read may block for up to 30 seconds if no
+> messages arrive.
+
+**Example call:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 12, "method": "tools/call",
+  "params": {
+    "name": "pulsar_peek",
+    "arguments": {
+      "topic": "persistent://public/default/demo",
+      "from": "earliest",
+      "max_messages": 3
+    }
+  }
+}
+```
+
+---
+
+## Next Steps (not yet implemented)
+
+- Stateful consumer sessions (open / receive / ack / close with handles)
+- TLS & Basic auth support
+- Schema-aware produce/consume
+- HTTP/SSE transport
+- MCP Resources & Prompts


### PR DESCRIPTION
## Summary

Add a self-contained **MCP (Model Context Protocol)** stdio server so that AI agents (Cursor, Claude Desktop, etc.) can operate Pulsar through this PHP library with zero additional dependencies.

### New files

- **`examples/mcp-server.php`** — Single-file MCP server over stdio JSON-RPC 2.0, PHP 7.1+ compatible
- **`examples/mcp.md`** — Setup guide with Cursor / Claude Desktop config snippets and full tool reference

### Tools exposed

| Tool | Description |
|---|---|
| `pulsar_publish` | Send a message with optional key, properties, and delivery delay |
| `pulsar_consume` | Consume up to N messages with auto-acknowledgement |
| `pulsar_peek` | Read messages via Reader (read-only, no subscription side effects) |

### Updated docs

- `README.md` / `README-CN.md` — Added "MCP Server" section with quick-start JSON config

## Usage

Add to `~/.cursor/mcp.json` or `claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "pulsar": {
      "command": "php",
      "args": ["/path/to/pulsar-client-php/examples/mcp-server.php"],
      "env": {
        "PULSAR_BROKER_URL": "pulsar://localhost:6650",
        "PULSAR_TOKEN": ""
      }
    }
  }
}
```

## Test Plan

**Prerequisites:** PHP >= 7.1, `composer install`, a running Pulsar broker.

```bash
# 1. Start a local Pulsar broker (if not running)
docker run -it --rm -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:latest bin/pulsar standalone

# 2. Verify MCP handshake and tool listing
printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n' \
  | php examples/mcp-server.php

# 3. Publish a message
printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"pulsar_publish","arguments":{"topic":"persistent://public/default/mcp-test","payload":"hello from MCP"}}}\n' \
  | php examples/mcp-server.php

# 4. Create a subscription first, then publish & consume
curl -s -X PUT http://localhost:8080/admin/v2/persistent/public/default/mcp-e2e/subscription/test-sub
printf '...initialize...\n{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"pulsar_publish","arguments":{"topic":"persistent://public/default/mcp-e2e","payload":"e2e test"}}}\n' \
  | php examples/mcp-server.php
printf '...initialize...\n{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"pulsar_consume","arguments":{"topic":"persistent://public/default/mcp-e2e","subscription":"test-sub","max_messages":5,"timeout_seconds":3}}}\n' \
  | php examples/mcp-server.php
```

**Tested against:** Pulsar 3.2.0 standalone, PHP 8.3.21 (library requires >= 7.1).


Made with [Cursor](https://cursor.com)