### PR TITLE
Fix CI JWT auth with pinned Pulsar Docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
         tags:
             - "v*"
 
+env:
+    PULSAR_IMAGE: apachepulsar/pulsar:3.3.6
+
 jobs:
     start:
         strategy:
@@ -27,7 +30,7 @@ jobs:
                 run: |
                     chmod -c o+w `pwd`/.github
                     ls -al
-                    docker run -itd --privileged --name pulsar -v `pwd`/.github:/pulsar/tokens -p 6650:6650 -p 8080:8080 apachepulsar/pulsar bin/pulsar standalone
+                    docker run -itd --privileged --name pulsar -v `pwd`/.github:/pulsar/tokens -p 6650:6650 -p 8080:8080 "${PULSAR_IMAGE}" bin/pulsar standalone
                     echo "-- Wait for Pulsar service to be ready"
                     until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
             
@@ -35,7 +38,9 @@ jobs:
             -   name: create authentication token
                 run: |
                     docker exec pulsar bin/pulsar tokens create-secret-key --output /pulsar/tokens/jwt.key --base64
-                    docker exec pulsar bin/pulsar tokens create --secret-key file:///pulsar/tokens/jwt.key --subject workflows > `pwd`/.github/jwt.token
+                    docker exec pulsar bash -lc 'bin/pulsar tokens create --secret-key file:///pulsar/tokens/jwt.key --subject workflows > /pulsar/tokens/jwt.token'
+                    test -s .github/jwt.token
+                    grep -q '^eyJ' .github/jwt.token
                     ls -al .github
                     cat .github/jwt.key
             
@@ -50,11 +55,13 @@ jobs:
             -   name: configure standalone.conf
                 run: |
                     docker cp pulsar:/pulsar/conf/standalone.conf .
-                    sed -i 's/authenticationEnabled=false/authenticationEnabled=true/g' standalone.conf
-                    sed -i 's/authenticationProviders=/authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken/g' standalone.conf
-                    sed -i 's/brokerClientAuthenticationPlugin=/brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken/g' standalone.conf
-                    sed -i 's/brokerClientAuthenticationParameters=/brokerClientAuthenticationParameters=file:\/\/\/pulsar\/tokens\/jwt.token/g' standalone.conf
-                    sed -i 's/tokenSecretKey=/tokenSecretKey=file:\/\/\/pulsar\/tokens\/jwt.key/g' standalone.conf
+                    sed -i -E 's/^authenticationEnabled=.*/authenticationEnabled=true/' standalone.conf
+                    sed -i -E 's/^authenticationProviders=.*/authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken/' standalone.conf
+                    sed -i -E 's/^brokerClientAuthenticationPlugin=.*/brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken/' standalone.conf
+                    sed -i -E 's|^brokerClientAuthenticationParameters=.*|brokerClientAuthenticationParameters=file:///pulsar/tokens/jwt.token|' standalone.conf
+                    sed -i -E 's|^tokenSecretKey=.*|tokenSecretKey=file:///pulsar/tokens/jwt.key|' standalone.conf
+                    grep -E '^authenticationEnabled=' standalone.conf | head -1
+                    grep -E '^tokenSecretKey=' standalone.conf | head -1
             
             # restart pulsar
             -   name: restart pulsar

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,6 +1,9 @@
 name: Dispatch Test Pulsar
 on: workflow_dispatch
 
+env:
+    PULSAR_IMAGE: apachepulsar/pulsar:3.3.6
+
 jobs:
     start:
         strategy:
@@ -24,7 +27,7 @@ jobs:
                 run: |
                     chmod -c o+w `pwd`/.github
                     ls -al
-                    docker run -itd --privileged --name pulsar -v `pwd`/.github:/pulsar/tokens -p 6650:6650 -p 8080:8080 apachepulsar/pulsar bin/pulsar standalone
+                    docker run -itd --privileged --name pulsar -v `pwd`/.github:/pulsar/tokens -p 6650:6650 -p 8080:8080 "${PULSAR_IMAGE}" bin/pulsar standalone
                     echo "-- Wait for Pulsar service to be ready"
                     until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
             
@@ -32,7 +35,9 @@ jobs:
             -   name: create authentication token
                 run: |
                     docker exec pulsar bin/pulsar tokens create-secret-key --output /pulsar/tokens/jwt.key --base64
-                    docker exec pulsar bin/pulsar tokens create --secret-key file:///pulsar/tokens/jwt.key --subject workflows > `pwd`/.github/jwt.token
+                    docker exec pulsar bash -lc 'bin/pulsar tokens create --secret-key file:///pulsar/tokens/jwt.key --subject workflows > /pulsar/tokens/jwt.token'
+                    test -s .github/jwt.token
+                    grep -q '^eyJ' .github/jwt.token
                     ls -al .github
                     cat .github/jwt.key
             
@@ -47,11 +52,13 @@ jobs:
             -   name: configure standalone.conf
                 run: |
                     docker cp pulsar:/pulsar/conf/standalone.conf .
-                    sed -i 's/authenticationEnabled=false/authenticationEnabled=true/g' standalone.conf
-                    sed -i 's/authenticationProviders=/authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken/g' standalone.conf
-                    sed -i 's/brokerClientAuthenticationPlugin=/brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken/g' standalone.conf
-                    sed -i 's/brokerClientAuthenticationParameters=/brokerClientAuthenticationParameters=file:\/\/\/pulsar\/tokens\/jwt.token/g' standalone.conf
-                    sed -i 's/tokenSecretKey=/tokenSecretKey=file:\/\/\/pulsar\/tokens\/jwt.key/g' standalone.conf
+                    sed -i -E 's/^authenticationEnabled=.*/authenticationEnabled=true/' standalone.conf
+                    sed -i -E 's/^authenticationProviders=.*/authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken/' standalone.conf
+                    sed -i -E 's/^brokerClientAuthenticationPlugin=.*/brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationToken/' standalone.conf
+                    sed -i -E 's|^brokerClientAuthenticationParameters=.*|brokerClientAuthenticationParameters=file:///pulsar/tokens/jwt.token|' standalone.conf
+                    sed -i -E 's|^tokenSecretKey=.*|tokenSecretKey=file:///pulsar/tokens/jwt.key|' standalone.conf
+                    grep -E '^authenticationEnabled=' standalone.conf | head -1
+                    grep -E '^tokenSecretKey=' standalone.conf | head -1
             
             # restart pulsar
             -   name: restart pulsar

--- a/examples/workflows/consumer.php
+++ b/examples/workflows/consumer.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 $options = new ConsumerOptions();
 
-$token = file_get_contents(__DIR__ . '/../../.github/jwt.token');
+$token = trim((string) file_get_contents(__DIR__ . '/../../.github/jwt.token'));
 $options->setAuthentication(new Jwt($token));
 
 $options->setConnectTimeout(3);

--- a/examples/workflows/keepalive.php
+++ b/examples/workflows/keepalive.php
@@ -65,7 +65,7 @@ class ProducerStore
         $options->setTopic($topic);
         $options->setCompression(Compression::ZLIB);
         $options->setKeepalive(true);
-        $token = file_get_contents(__DIR__ . '/../../.github/jwt.token');
+        $token = trim((string) file_get_contents(__DIR__ . '/../../.github/jwt.token'));
         $options->setAuthentication(new Jwt($token));
 
         $producer = new Producer('pulsar://localhost:6650', $options);

--- a/examples/workflows/producer.php
+++ b/examples/workflows/producer.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 $options = new ProducerOptions();
 
-$token = file_get_contents(__DIR__ . '/../../.github/jwt.token');
+$token = trim((string) file_get_contents(__DIR__ . '/../../.github/jwt.token'));
 
 $options->setAuthentication(new Jwt($token));
 


### PR DESCRIPTION
## Summary

- Pin CI to `apachepulsar/pulsar:3.3.6` so `latest` upgrades cannot silently break workflows.
- Generate `jwt.token` inside the mounted volume so JVM/CLI stdout noise cannot corrupt the token file when using host-side redirects.
- Replace fragile `sed` substitutions with line-anchored replacements and print the resulting auth lines for easier CI debugging.
- Trim JWT file contents in workflow examples to tolerate trailing newlines.

## Test plan

- [ ] Push a tag or run the dispatch workflow and confirm the Pulsar + PHP matrix passes.

Made with [Cursor](https://cursor.com)