### PR TITLE
fix: include sequence ID in producer message metadata

### DIFF
--- a/src/Util/Builder.php
+++ b/src/Util/Builder.php
@@ -145,7 +145,7 @@ class Builder
         // metadata
         $metadata = new MessageMetadata();
         $metadata->setProducerName($this->producer->getName());
-        $metadata->setSequenceId(0);
+        $metadata->setSequenceId($this->sequenceID);
         $metadata->setPublishTime(time() * 1000);
         $metadata->setNumMessagesInBatch(count($this->messages));
         $metadata->setCompression($compressionProvider->getType());


### PR DESCRIPTION
## Summary

Fix the producer to include the sequence ID in the message metadata.

## Problem

When a message with a sequence ID is published to Pulsar, deduplication works correctly. However, the sequence ID is not included in `MessageMetadata`. 

The sequence ID is correctly set in `CommandSend`, but the current implementation always sets it to zero in `MessageMetadata`:
```php
$metadata->setSequenceId(0);
```
[Code line](https://github.com/ikilobyte/pulsar-client-php/blob/5b6599dc9b5083cd5518c6a5f8a960e63e725981/src/Util/Builder.php#L148)

As a result, it is difficult to troubleshoot deduplication issues using applications such as Dekaf or the Pulsar REST API.


## Solution

Update the producer to include the configured sequence ID in both `CommandSend` and `MessageMetadata`:

```php
$metadata->setSequenceId($this->sequenceID);
```

## Evidence

### Before the Fix

The following message was published with sequence ID `22`, but its metadata incorrectly reports `0`:

<img width="663" height="516" alt="image" src="https://github.com/user-attachments/assets/d7af612f-0ba2-4ce5-9538-c87470dd8d59" />

### After the Fix

After applying the fix, the metadata correctly reports the sequence ID `23` sent by the producer:

<img width="663" height="516" alt="image" src="https://github.com/user-attachments/assets/ebfbe56a-51fe-413c-8566-a39c42dbe14c" />

## Related issue

Fixes #46


